### PR TITLE
Refactor the request object to use alias instead of user objects

### DIFF
--- a/app/src/main/java/edu/byu/cs/tweeter/client/view/main/following/FollowingFragment.java
+++ b/app/src/main/java/edu/byu/cs/tweeter/client/view/main/following/FollowingFragment.java
@@ -263,7 +263,7 @@ public class FollowingFragment extends Fragment implements FollowingPresenter.Vi
             addLoadingFooter();
 
             GetFollowingTask getFollowingTask = new GetFollowingTask(presenter, this);
-            FollowingRequest request = new FollowingRequest(user, PAGE_SIZE, lastFollowee);
+            FollowingRequest request = new FollowingRequest(user.getAlias(), PAGE_SIZE, lastFollowee.getAlias());
             getFollowingTask.execute(request);
         }
 

--- a/app/src/test/java/edu/byu/cs/tweeter/client/model/service/FollowingServiceProxyTest.java
+++ b/app/src/test/java/edu/byu/cs/tweeter/client/model/service/FollowingServiceProxyTest.java
@@ -41,7 +41,7 @@ public class FollowingServiceProxyTest {
                 "https://faculty.cs.byu.edu/~jwilkerson/cs340/tweeter/images/daisy_duck.png");
 
         // Setup request objects to use in the tests
-        validRequest = new FollowingRequest(currentUser, 3, null);
+        validRequest = new FollowingRequest(currentUser.getAlias(), 3, null);
         invalidRequest = new FollowingRequest(null, 0, null);
 
         // Setup a mock ServerFacade that will return known responses

--- a/app/src/test/java/edu/byu/cs/tweeter/client/presenter/FollowingPresenterTest.java
+++ b/app/src/test/java/edu/byu/cs/tweeter/client/presenter/FollowingPresenterTest.java
@@ -32,7 +32,7 @@ public class FollowingPresenterTest {
         User resultUser3 = new User("FirstName3", "LastName3",
                 "https://faculty.cs.byu.edu/~jwilkerson/cs340/tweeter/images/daisy_duck.png");
 
-        request = new FollowingRequest(currentUser, 3, null);
+        request = new FollowingRequest(currentUser.getAlias(), 3, null);
         response = new FollowingResponse(Arrays.asList(resultUser1, resultUser2, resultUser3), false);
 
         // Create a mock FollowingService

--- a/server/src/main/java/edu/byu/cs/tweeter/server/dao/FollowingDAO.java
+++ b/server/src/main/java/edu/byu/cs/tweeter/server/dao/FollowingDAO.java
@@ -63,7 +63,7 @@ public class FollowingDAO {
     public FollowingResponse getFollowees(FollowingRequest request) {
         // TODO: Generates dummy data. Replace with a real implementation.
         assert request.getLimit() > 0;
-        assert request.getFollower() != null;
+        assert request.getFollowerAlias() != null;
 
         List<User> allFollowees = getDummyFollowees();
         List<User> responseFollowees = new ArrayList<>(request.getLimit());
@@ -72,7 +72,7 @@ public class FollowingDAO {
 
         if(request.getLimit() > 0) {
             if (allFollowees != null) {
-                int followeesIndex = getFolloweesStartingIndex(request.getLastFollowee(), allFollowees);
+                int followeesIndex = getFolloweesStartingIndex(request.getLastFolloweeAlias(), allFollowees);
 
                 for(int limitCounter = 0; followeesIndex < allFollowees.size() && limitCounter < request.getLimit(); followeesIndex++, limitCounter++) {
                     responseFollowees.add(allFollowees.get(followeesIndex));
@@ -90,20 +90,20 @@ public class FollowingDAO {
      * be returned in the current request. This will be the index of the next followee after the
      * specified 'lastFollowee'.
      *
-     * @param lastFollowee the last followee that was returned in the previous request or null if
-     *                     there was no previous request.
+     * @param lastFolloweeAlias the alias of the last followee that was returned in the previous
+     *                          request or null if there was no previous request.
      * @param allFollowees the generated list of followees from which we are returning paged results.
      * @return the index of the first followee to be returned.
      */
-    private int getFolloweesStartingIndex(User lastFollowee, List<User> allFollowees) {
+    private int getFolloweesStartingIndex(String lastFolloweeAlias, List<User> allFollowees) {
 
         int followeesIndex = 0;
 
-        if(lastFollowee != null) {
+        if(lastFolloweeAlias != null) {
             // This is a paged request for something after the first page. Find the first item
             // we should return
             for (int i = 0; i < allFollowees.size(); i++) {
-                if(lastFollowee.equals(allFollowees.get(i))) {
+                if(lastFolloweeAlias.equals(allFollowees.get(i).getAlias())) {
                     // We found the index of the last item returned last time. Increment to get
                     // to the first one we should return
                     followeesIndex = i + 1;

--- a/server/src/test/java/edu/byu/cs/tweeter/server/dao/FollowingDAOTest.java
+++ b/server/src/test/java/edu/byu/cs/tweeter/server/dao/FollowingDAOTest.java
@@ -36,7 +36,7 @@ class FollowingDAOTest {
         List<User> followees = Collections.emptyList();
         Mockito.when(followingDAOSpy.getDummyFollowees()).thenReturn(followees);
 
-        FollowingRequest request = new FollowingRequest(user1, 10, null);
+        FollowingRequest request = new FollowingRequest(user1.getAlias(), 10, null);
         FollowingResponse response = followingDAOSpy.getFollowees(request);
 
         Assertions.assertEquals(0, response.getFollowees().size());
@@ -48,7 +48,7 @@ class FollowingDAOTest {
         List<User> followees = Collections.singletonList(user2);
         Mockito.when(followingDAOSpy.getDummyFollowees()).thenReturn(followees);
 
-        FollowingRequest request = new FollowingRequest(user1, 10, null);
+        FollowingRequest request = new FollowingRequest(user1.getAlias(), 10, null);
         FollowingResponse response = followingDAOSpy.getFollowees(request);
 
         Assertions.assertEquals(1, response.getFollowees().size());
@@ -61,7 +61,7 @@ class FollowingDAOTest {
         List<User> followees = Arrays.asList(user2, user3);
         Mockito.when(followingDAOSpy.getDummyFollowees()).thenReturn(followees);
 
-        FollowingRequest request = new FollowingRequest(user3, 2, null);
+        FollowingRequest request = new FollowingRequest(user3.getAlias(), 2, null);
         FollowingResponse response = followingDAOSpy.getFollowees(request);
 
         Assertions.assertEquals(2, response.getFollowees().size());
@@ -75,7 +75,7 @@ class FollowingDAOTest {
         List<User> followees = Arrays.asList(user2, user3, user4, user5, user6, user7);
         Mockito.when(followingDAOSpy.getDummyFollowees()).thenReturn(followees);
 
-        FollowingRequest request = new FollowingRequest(user5, 2, null);
+        FollowingRequest request = new FollowingRequest(user5.getAlias(), 2, null);
         FollowingResponse response = followingDAOSpy.getFollowees(request);
 
         // Verify first page
@@ -85,7 +85,7 @@ class FollowingDAOTest {
         Assertions.assertTrue(response.getHasMorePages());
 
         // Get and verify second page
-        request = new FollowingRequest(user5, 2, response.getFollowees().get(1));
+        request = new FollowingRequest(user5.getAlias(), 2, response.getFollowees().get(1).getAlias());
         response = followingDAOSpy.getFollowees(request);
 
         Assertions.assertEquals(2, response.getFollowees().size());
@@ -94,7 +94,7 @@ class FollowingDAOTest {
         Assertions.assertTrue(response.getHasMorePages());
 
         // Get and verify third page
-        request = new FollowingRequest(user5, 2, response.getFollowees().get(1));
+        request = new FollowingRequest(user5.getAlias(), 2, response.getFollowees().get(1).getAlias());
         response = followingDAOSpy.getFollowees(request);
 
         Assertions.assertEquals(2, response.getFollowees().size());
@@ -109,7 +109,7 @@ class FollowingDAOTest {
         List<User> followees = Arrays.asList(user2, user3, user4, user5, user6, user7, user8);
         Mockito.when(followingDAOSpy.getDummyFollowees()).thenReturn(followees);
 
-        FollowingRequest request = new FollowingRequest(user6, 2, null);
+        FollowingRequest request = new FollowingRequest(user6.getAlias(), 2, null);
         FollowingResponse response = followingDAOSpy.getFollowees(request);
 
         // Verify first page
@@ -119,7 +119,7 @@ class FollowingDAOTest {
         Assertions.assertTrue(response.getHasMorePages());
 
         // Get and verify second page
-        request = new FollowingRequest(user6, 2, response.getFollowees().get(1));
+        request = new FollowingRequest(user6.getAlias(), 2, response.getFollowees().get(1).getAlias());
         response = followingDAOSpy.getFollowees(request);
 
         Assertions.assertEquals(2, response.getFollowees().size());
@@ -128,7 +128,7 @@ class FollowingDAOTest {
         Assertions.assertTrue(response.getHasMorePages());
 
         // Get and verify third page
-        request = new FollowingRequest(user6, 2, response.getFollowees().get(1));
+        request = new FollowingRequest(user6.getAlias(), 2, response.getFollowees().get(1).getAlias());
         response = followingDAOSpy.getFollowees(request);
 
         Assertions.assertEquals(2, response.getFollowees().size());
@@ -137,7 +137,7 @@ class FollowingDAOTest {
         Assertions.assertTrue(response.getHasMorePages());
 
         // Get and verify fourth page
-        request = new FollowingRequest(user6, 2, response.getFollowees().get(1));
+        request = new FollowingRequest(user6.getAlias(), 2, response.getFollowees().get(1).getAlias());
         response = followingDAOSpy.getFollowees(request);
 
         Assertions.assertEquals(1, response.getFollowees().size());

--- a/server/src/test/java/edu/byu/cs/tweeter/server/service/FollowingServiceImplTest.java
+++ b/server/src/test/java/edu/byu/cs/tweeter/server/service/FollowingServiceImplTest.java
@@ -33,7 +33,7 @@ public class FollowingServiceImplTest {
                 "https://faculty.cs.byu.edu/~jwilkerson/cs340/tweeter/images/daisy_duck.png");
 
         // Setup a request object to use in the tests
-        request = new FollowingRequest(currentUser, 3, null);
+        request = new FollowingRequest(currentUser.getAlias(), 3, null);
 
         // Setup a mock FollowingDAO that will return known responses
         expectedResponse = new FollowingResponse(Arrays.asList(resultUser1, resultUser2, resultUser3), false);

--- a/shared/src/main/java/edu/byu/cs/tweeter/model/service/request/FollowingRequest.java
+++ b/shared/src/main/java/edu/byu/cs/tweeter/model/service/request/FollowingRequest.java
@@ -1,16 +1,14 @@
 package edu.byu.cs.tweeter.model.service.request;
 
-import edu.byu.cs.tweeter.model.domain.User;
-
 /**
  * Contains all the information needed to make a request to have the server return the next page of
  * followees for a specified follower.
  */
 public class FollowingRequest {
 
-    private User follower;
+    private String followerAlias;
     private int limit;
-    private User lastFollowee;
+    private String lastFolloweeAlias;
 
     /**
      * Allows construction of the object from Json. Private so it won't be called in normal code.
@@ -20,16 +18,16 @@ public class FollowingRequest {
     /**
      * Creates an instance.
      *
-     * @param follower the {@link User} whose followees are to be returned.
+     * @param followerAlias the alias of the user whose followees are to be returned.
      * @param limit the maximum number of followees to return.
-     * @param lastFollowee the last followee that was returned in the previous request (null if
+     * @param lastFolloweeAlias the alias of the last followee that was returned in the previous request (null if
      *                     there was no previous request or if no followees were returned in the
      *                     previous request).
      */
-    public FollowingRequest(User follower, int limit, User lastFollowee) {
-        this.follower = follower;
+    public FollowingRequest(String followerAlias, int limit, String lastFolloweeAlias) {
+        this.followerAlias = followerAlias;
         this.limit = limit;
-        this.lastFollowee = lastFollowee;
+        this.lastFolloweeAlias = lastFolloweeAlias;
     }
 
     /**
@@ -37,17 +35,17 @@ public class FollowingRequest {
      *
      * @return the follower.
      */
-    public User getFollower() {
-        return follower;
+    public String getFollowerAlias() {
+        return followerAlias;
     }
 
     /**
      * Sets the follower.
      *
-     * @param follower the follower.
+     * @param followerAlias the follower.
      */
-    public void setFollower(User follower) {
-        this.follower = follower;
+    public void setFollowerAlias(String followerAlias) {
+        this.followerAlias = followerAlias;
     }
 
     /**
@@ -74,16 +72,16 @@ public class FollowingRequest {
      *
      * @return the last followee.
      */
-    public User getLastFollowee() {
-        return lastFollowee;
+    public String getLastFolloweeAlias() {
+        return lastFolloweeAlias;
     }
 
     /**
      * Sets the last followee.
      *
-     * @param lastFollowee the last followee.
+     * @param lastFolloweeAlias the last followee.
      */
-    public void setLastFollowee(User lastFollowee) {
-        this.lastFollowee = lastFollowee;
+    public void setLastFolloweeAlias(String lastFolloweeAlias) {
+        this.lastFolloweeAlias = lastFolloweeAlias;
     }
 }


### PR DESCRIPTION
Replace the user objects in the FollowingRequest with respective aliases.

When this is accepted, I'll create PRs for the other 3 branches.